### PR TITLE
  feat: support per-node governor power models

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,34 @@ To collect node measurements for CPU and Memory energy consumption, refer to the
 For the current version, replicating the previous calculation approach noted in the Credits section, example usage has been provided with default values:
 ```
 $ python -m src.scripts.IchnosCF <trace-name> <ci-value|ci-file-name> <power_model> <? interval=60> <? pue=1.0> <? memory-coeff=0.392>
-$ python3 -m src.scripts.IchnosCF ampliseq-1 uk-marg-010125-110225 gpg_15_powersave_linear 5 1.0 0.392
-```      
+$ python3 -m src.scripts.IchnosCF ampliseq-1 uk-marg-010125-110225 powersave_linear 5 1.0 0.392
+```
 
-> **Note**  
+## Specifying Node Governors
+
+The default CLI option still exists. When using positional CLI arguments, the governor is taken from the `<power_model>` value and used for every node. For example, `powersave_linear` uses each node's configured `powersave` linear model.
+
+To override governors for specific nodes, use a YAML config file with the `node-governors` key:
+```
+trace: rnaseq-2
+carbon-intensity: 1
+model-name: powersave_linear
+interval: 60
+pue: 1.0
+memory-coefficient: 0.392
+node-governors:
+  node-04: performance
+  node-05: usersched
+```
+
+Run Ichnos with the config file:
+```
+$ python3 -m src.scripts.IchnosCF -c path/to/config.yaml
+```
+
+In this example, `node-04` uses `performance_linear`, `node-05` uses `powersave_linear`, and nodes not listed under `node-governors` continue to use the governor from `model-name` (`powersave_linear`). The `node-governors` value can also be a path to a JSON file containing the same node-to-governor mapping.
+
+> **Note**
 > The trace file name must be the file name only, and traces should be csv files stored in the [data trace](data/trace/) directory!
 
 > **Note**  

--- a/src/Constants.py
+++ b/src/Constants.py
@@ -29,6 +29,7 @@ RESERVED_MEMORY = "reserved-memory"
 NUM_OF_NODES = "num-of-nodes"
 TASK_FLAG = True
 MODEL_NAME = 'model-name' 
+NODE_GOVERNORS = "node-governors"
 
 # FetchCarbonIntensity Constants
 NG_BASE_URL = "https://api.carbonintensity.org.uk/"

--- a/src/scripts/IchnosCF.py
+++ b/src/scripts/IchnosCF.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Dict, List, Tuple, Union
 from src.utils.TimeUtils import to_timestamp, extract_tasks_by_interval
@@ -14,6 +15,35 @@ from src.models.TaskExtractionResult import TaskExtractionResult
 
 import sys
 
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_node_governors(value) -> Dict[str, str]:
+    if value is None:
+        return {}
+    if isinstance(value, str):
+        try:
+            with open(value, "r", encoding="utf-8") as handle:
+                value = json.load(handle)
+        except Exception as exc:
+            logger.warning("Ignoring node-governors from %s: %s", value, exc)
+            return {}
+    if not isinstance(value, dict):
+        logger.warning("Ignoring node-governors: expected a mapping or JSON file path, got %s", type(value).__name__)
+        return {}
+    normalized: Dict[str, str] = {}
+    for node, governor in value.items():
+        if isinstance(governor, dict):
+            governor = governor.get("dominant_governor") or governor.get("governor")
+        node_text = str(node).strip()
+        governor_text = str(governor).strip() if governor is not None else ""
+        if node_text and governor_text:
+            normalized[node_text] = governor_text
+        else:
+            logger.warning("Ignoring empty node governor entry for node %r", node)
+    return normalized
+
 def main(arguments: Dict[str, Union[str, float, int]]) -> IchnosResult:
     """
     Main function to compute and report the carbon footprint.
@@ -28,6 +58,7 @@ def main(arguments: Dict[str, Union[str, float, int]]) -> IchnosResult:
     interval: int = arguments[INTERVAL]
     model_name: str = arguments[MODEL_NAME]
     memory_coefficient: float = arguments[MEMORY_COEFFICIENT]
+    node_governors: Dict[str, str] = normalize_node_governors(arguments.get(NODE_GOVERNORS))
 
     if memory_coefficient is None:
         memory_coefficient = DEFAULT_MEMORY_POWER_DRAW
@@ -52,6 +83,8 @@ def main(arguments: Dict[str, Union[str, float, int]]) -> IchnosResult:
     summary += f"- carbon-intensity: {arguments[CI]}\n"
     summary += f"- power-usage-effectiveness: {pue}\n"
     summary += f"- power model selected: {model_name}\n"
+    if node_governors:
+        summary += f"- node governors: {json.dumps(node_governors, sort_keys=True)}\n"
     summary += f"- memory-power-draw: {memory_coefficient}\n"
 
     if isinstance(arguments[CI], float):
@@ -95,7 +128,8 @@ def main(arguments: Dict[str, Union[str, float, int]]) -> IchnosResult:
         ewif=ewif, 
         wue=wue, 
         elif_=elif_, 
-        lue=lue
+        lue=lue,
+        node_governors=node_governors
     )
     cpu_energy = op_carbon_result.cpu_energy
     cpu_energy_pue = op_carbon_result.cpu_energy_pue

--- a/src/scripts/OperationalCarbon.py
+++ b/src/scripts/OperationalCarbon.py
@@ -84,7 +84,7 @@ def estimate_task_energy_consumption_ccf(task: IchnosTrace, model: Callable[[flo
 
 
 # Estimate Carbon Footprint 
-def calculate_carbon_footprint_ccf(tasks_grouped_by_interval: Dict[datetime, List[IchnosTrace]], ci: Union[float, Dict[str, float]], pue: float, model_name: str, memory_coefficient: float, unique_nodes: List[str], check_node_memory: bool = False, ewif: Union[float, Dict[str, float]]= None, wue: float = None, elif_: Union[float, Dict[str, float]] = None, lue: float = None ) -> OperationalCarbonResult:
+def calculate_carbon_footprint_ccf(tasks_grouped_by_interval: Dict[datetime, List[IchnosTrace]], ci: Union[float, Dict[str, float]], pue: float, model_name: str, memory_coefficient: float, unique_nodes: List[str], check_node_memory: bool = False, ewif: Union[float, Dict[str, float]]= None, wue: float = None, elif_: Union[float, Dict[str, float]] = None, lue: float = None, node_governors: Dict[str, str] = None ) -> OperationalCarbonResult:
     """
     Calculate the carbon footprint using the CCF methodology.
     
@@ -117,9 +117,10 @@ def calculate_carbon_footprint_ccf(tasks_grouped_by_interval: Dict[datetime, Lis
     node_system_cores: Dict[str, int] = {}
     node_memory: Dict[str, float] = {}
 
+    node_governors = node_governors or {}
     for node in unique_nodes: 
-        node_power_models[node] = get_power_model_for_node(node, model_name)
-        node_memory_coeffs[node] = get_memory_draw(node, model_name)
+        node_power_models[node] = get_power_model_for_node(node, model_name, node_governors)
+        node_memory_coeffs[node] = get_memory_draw(node, model_name, node_governors)
         node_system_cores[node] = get_system_cores(node)
         node_memory[node] = get_system_memory(node)
 

--- a/src/utils/NodeConfigModelReader.py
+++ b/src/utils/NodeConfigModelReader.py
@@ -1,8 +1,12 @@
 import json
+import logging
+from typing import Dict, Optional
+
 from src.Constants import DEFAULT_MEMORY_POWER_DRAW
 
 
 node_config = None
+logger = logging.getLogger(__name__)
 
 
 def load_node_config():
@@ -13,16 +17,41 @@ def load_node_config():
     return node_config
 
 
+def get_model_governor(node_id: str, model_name: str, node_governors: Optional[Dict[str, str]] = None) -> str:
+    load_node_config()
+    fallback = model_name.split('_', 1)[0] if model_name else ''
+    override = None
+    if node_governors:
+        override = node_governors.get(node_id)
+    if override and node_id in node_config and override in node_config[node_id]:
+        return override
+    if override:
+        if node_id not in node_config:
+            logger.warning(
+                "Ignoring node governor override for %s=%s: node is not configured; using %s",
+                node_id,
+                override,
+                fallback,
+            )
+        else:
+            logger.warning(
+                "Ignoring node governor override for %s=%s: governor is not configured for node; using %s",
+                node_id,
+                override,
+                fallback,
+            )
+    return fallback
+
+
 def get_cpu_model(node_id: str) -> str:
     load_node_config()
     return node_config[node_id]['cpu_model']
 
 
-def get_memory_draw(node_id: str, model_name: str) -> float:
+def get_memory_draw(node_id: str, model_name: str, node_governors: Optional[Dict[str, str]] = None) -> float:
     load_node_config()
     try:
-        model_data = model_name.split('_')
-        governor: str = model_data[0]
+        governor: str = get_model_governor(node_id, model_name, node_governors)
         return node_config[node_id][governor]['mem_draw']
     except:
         return DEFAULT_MEMORY_POWER_DRAW

--- a/src/utils/PowerModel.py
+++ b/src/utils/PowerModel.py
@@ -1,28 +1,40 @@
 from typing import Callable
 import src.utils.MathModels as MathModels
-from src.utils.NodeConfigModelReader import load_node_config
+from src.utils.NodeConfigModelReader import get_model_governor, load_node_config
 
 
-def get_power_model_for_node(node_id: str, model_name: str) -> Callable[[float], float]:
-    print(f'Node {node_id} with power model {model_name} selected')
+def get_power_model_for_node(node_id: str, model_name: str, node_governors: dict[str, str] | None = None) -> Callable[[float], float]:
     node_config = load_node_config()
 
     # Get the model data
     model_data = model_name.split('_')
-    governor: str = model_data[0]
+    if len(model_data) < 2:
+        raise ValueError(f"Power model name must include governor and model type, got {model_name!r}")
+    if node_id not in node_config:
+        raise ValueError(f"Node {node_id!r} is not configured in node_config_models/nodes.json")
+    governor: str = get_model_governor(node_id, model_name, node_governors)
     model_type: str = model_data[1]
 
     if model_type == 'minmax':
+        if governor not in node_config[node_id]:
+            raise ValueError(f"Node {node_id!r} does not define governor {governor!r}")
         min_watts = node_config[node_id][governor]['min_watts']
         max_watts = node_config[node_id][governor]['max_watts']
+        print(f'Node {node_id} with power model {governor}_{model_type} selected')
         return (MathModels.min_max_linear_power_model(min_watts, max_watts), min_watts)
     elif model_type == 'baseline':
         tdp_per_core = node_config[node_id]['tdp_per_core']
+        print(f'Node {node_id} with power model {governor}_{model_type} selected')
         return (MathModels.baseline_linear_power_model(tdp_per_core), 0)
     elif model_type == 'linear':
+        if governor not in node_config[node_id]:
+            raise ValueError(f"Node {node_id!r} does not define governor {governor!r}")
         linear_vals = node_config[node_id][governor]['linear']
         coeff = linear_vals[0]
         inter = linear_vals[1]
+        print(f'Node {node_id} with power model {governor}_{model_type} selected')
         return (MathModels.fitted_linear_power_model(coeff, inter), inter)
 
-    return (MathModels.polynomial_model(node_config[node_id][governor][model_type]), inter)  # this should not be used...
+    raise ValueError(
+        f"Node {node_id!r} governor {governor!r} does not define model type {model_type!r}"
+    )

--- a/tests/test_node_governors.py
+++ b/tests/test_node_governors.py
@@ -1,0 +1,56 @@
+import json
+import os
+import tempfile
+import unittest
+
+from src.scripts.IchnosCF import normalize_node_governors
+from src.utils.NodeConfigModelReader import get_model_governor
+from src.utils.PowerModel import get_power_model_for_node
+
+
+class NodeGovernorTests(unittest.TestCase):
+    def test_invalid_json_governor_file_warns_and_is_ignored(self):
+        with tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8") as handle:
+            handle.write("{")
+            path = handle.name
+
+        try:
+            with self.assertLogs("src.scripts.IchnosCF", level="WARNING") as logs:
+                self.assertEqual(normalize_node_governors(path), {})
+        finally:
+            os.unlink(path)
+
+        self.assertIn("Ignoring node-governors", "\n".join(logs.output))
+
+    def test_unknown_node_governor_override_warns_and_falls_back(self):
+        with self.assertLogs("src.utils.NodeConfigModelReader", level="WARNING") as logs:
+            governor = get_model_governor(
+                "gpgnode-04",
+                "powersave_linear",
+                {"gpgnode-04": "not-a-governor"},
+            )
+
+        self.assertEqual(governor, "powersave")
+        self.assertIn("Ignoring node governor override", "\n".join(logs.output))
+
+    def test_missing_model_type_for_selected_governor_has_clear_error(self):
+        with self.assertRaisesRegex(ValueError, "does not define model type"):
+            get_power_model_for_node(
+                "gpgnode-22",
+                "powersave_polynomial",
+                {"gpgnode-22": "performance"},
+            )
+
+    def test_governor_file_supports_nested_governor_records(self):
+        with tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8") as handle:
+            json.dump({"gpgnode-04": {"dominant_governor": "performance"}}, handle)
+            path = handle.name
+
+        try:
+            self.assertEqual(normalize_node_governors(path), {"gpgnode-04": "performance"})
+        finally:
+            os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  - add node-governors input support for per-host governor overrides
  - apply resolved governors to CPU power models and memory draw lookup
  - include selected node governors in Ichnos summaries
  - warn when governor override input is invalid or ignored
  - raise clear errors for unsupported node/governor/model combinations
  - add tests covering governor override parsing, warnings, and validation